### PR TITLE
Include a captive portal when we are in AP mode

### DIFF
--- a/ducky.ino
+++ b/ducky.ino
@@ -69,6 +69,7 @@ const char* ssidnet = "WifiName"; // Change to network name you want to connect 
 const char* passwordnet = "WifiPassword"; // Change to network password
 String loginname = "root"; // Login page username
 String loginpassword = "toor"; // Login page password
+const byte DNS_PORT  = 53;
 IPAddress local_ip(192,168,0,1);
 IPAddress gateway(192,168,0,1);
 IPAddress subnet(255,255,255,0);
@@ -76,6 +77,7 @@ long randNumber;
 
 //Server handling
 AsyncWebServer server(80);
+DNSServer dnsServer;
 String header;
 
 String chars[60] = {
@@ -435,6 +437,8 @@ void setup() {
   // Connect to Wi-Fi
   if (apmode) {
     wifi_setup(ssidap, passwordap);
+    // We are an AP, so why not do a captive portal here?
+    dnsServer.start(DNS_PORT, "*", IP);
   }
   else {
     wifi_setup(ssidnet, passwordnet);
@@ -465,6 +469,10 @@ void setup() {
     if(!request->authenticate((char *)loginname.c_str(), (char *)loginpassword.c_str()))
       return request->requestAuthentication();
     request->send_P(200, "text/html", (char *)SendHTML().c_str());
+  });
+
+  server.on("/generate_204", HTTP_GET, [](AsyncWebServerRequest *request){
+    request->redirect("/"); // redirect to our main page
   });
 /*
   server.on(secretpagechar(), HTTP_GET, [](AsyncWebServerRequest *request){
@@ -545,6 +553,9 @@ void setup() {
 }
 
 void loop() {
+  if (apmode) {
+    dnsServer.processNextRequest();           // Don't forget the damn dns request processing if captive portal!
+  }
   // read the pushbutton:
   int buttonState = digitalRead(buttonPin);
   // if the button state has changed,

--- a/ducky.ino
+++ b/ducky.ino
@@ -439,7 +439,7 @@ void setup() {
   if (apmode) {
     wifi_setup(ssidap, passwordap);
     // We are an AP, so why not do a captive portal here?
-    dnsServer.start(DNS_PORT, "*", IP);
+    dnsServer.start(DNS_PORT, "*", "192.168.0.1");
   }
   else {
     wifi_setup(ssidnet, passwordnet);

--- a/ducky.ino
+++ b/ducky.ino
@@ -43,7 +43,8 @@ void setup(){}
 void loop(){}
 #else
 
-#include <WiFi.h>
+#include "WiFi.h"
+#include "DNSServer.h"
 #include "AsyncTCP.h"
 #include "ESPAsyncWebServer.h"
 #include "SD_MMC.h"


### PR DESCRIPTION
Captive portal is basically acting on (android) connectivity checks leading us to the web-interface to 'sign in' to the network.